### PR TITLE
Add extra argument for node walking to traverse templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Added** Option to to node traversal methods to traverse templates
+
 ## [v2.0.1](https://github.com/PolymerLabs/dom5/tree/v2.0.1) (2016-11-01)
 - TypeScript type definition fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Added** Option to to node traversal methods to traverse templates
+- **Added** Option to node traversal methods to traverse templates
 
 ## [v2.0.1](https://github.com/PolymerLabs/dom5/tree/v2.0.1) (2016-11-01)
 - TypeScript type definition fixes

--- a/dom5.ts
+++ b/dom5.ts
@@ -317,8 +317,10 @@ export type childNodesRetriever = (node: Node) => Node[] | undefined;
 const defaultChildNodes: childNodesRetriever = node => node.childNodes;
 
 export const childNodesIncludeTemplate: childNodesRetriever = node => {
-  if (node.nodeName === 'template')
+  if (node.nodeName === 'template') {
     return treeAdapters.default.getTemplateContent(node).childNodes;
+  }
+
   return node.childNodes;
 };
 

--- a/dom5.ts
+++ b/dom5.ts
@@ -312,11 +312,11 @@ export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
   return results;
 }
 
-export type childNodesRetriever = (node: Node) => Node[] | undefined;
+export type GetChildNodes = (node: Node) => Node[] | undefined;
 
-const defaultChildNodes: childNodesRetriever = node => node.childNodes;
+export const defaultChildNodes: GetChildNodes = node => node.childNodes;
 
-export const childNodesIncludeTemplate: childNodesRetriever = node => {
+export const childNodesIncludeTemplate: GetChildNodes = node => {
   if (node.nodeName === 'template') {
     return treeAdapters.default.getTemplateContent(node).childNodes;
   }
@@ -333,15 +333,15 @@ export const childNodesIncludeTemplate: childNodesRetriever = node => {
 export function nodeWalk(
     node: Node,
     predicate: Predicate,
-    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node|null {
+    getChildNodes: GetChildNodes = defaultChildNodes): Node|null {
   if (predicate(node)) {
     return node;
   }
   let match: Node|null = null;
-  const childNodes = retrieveChildNodes(node);
+  const childNodes = getChildNodes(node);
   if (childNodes) {
     for (let i = 0; i < childNodes.length; i++) {
-      match = nodeWalk(childNodes[i], predicate, retrieveChildNodes);
+      match = nodeWalk(childNodes[i], predicate, getChildNodes);
       if (match) {
         break;
       }
@@ -359,17 +359,17 @@ export function nodeWalkAll(
     node: Node,
     predicate: Predicate,
     matches?: Node[],
-    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node[] {
+    getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
   if (!matches) {
     matches = [];
   }
   if (predicate(node)) {
     matches.push(node);
   }
-  const childNodes = retrieveChildNodes(node);
+  const childNodes = getChildNodes(node);
   if (childNodes) {
     for (let i = 0; i < childNodes.length; i++) {
-      nodeWalkAll(childNodes[i], predicate, matches, retrieveChildNodes);
+      nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
     }
   }
   return matches;
@@ -379,14 +379,14 @@ function _reverseNodeWalkAll(
     node: Node,
     predicate: Predicate,
     matches: Node[],
-    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node[] {
+    getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
   if (!matches) {
     matches = [];
   }
-  const childNodes = retrieveChildNodes(node);
+  const childNodes = getChildNodes(node);
   if (childNodes) {
     for (let i = childNodes.length - 1; i >= 0; i--) {
-      nodeWalkAll(childNodes[i], predicate, matches, retrieveChildNodes);
+      nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
     }
   }
   if (predicate(node)) {
@@ -477,9 +477,9 @@ export function nodeWalkAllPrior(
 export function query(
     node: Node,
     predicate: Predicate,
-    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node|null {
+    getChildNodes: GetChildNodes = defaultChildNodes): Node|null {
   const elementPredicate = AND(isElement, predicate);
-  return nodeWalk(node, elementPredicate, retrieveChildNodes);
+  return nodeWalk(node, elementPredicate, getChildNodes);
 }
 
 /**
@@ -489,9 +489,9 @@ export function queryAll(
     node: Node,
     predicate: Predicate,
     matches?: Node[],
-    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node[] {
+    getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
   const elementPredicate = AND(isElement, predicate);
-  return nodeWalkAll(node, elementPredicate, matches, retrieveChildNodes);
+  return nodeWalkAll(node, elementPredicate, matches, getChildNodes);
 }
 
 function newTextNode(value: string): Node {

--- a/dom5.ts
+++ b/dom5.ts
@@ -14,7 +14,7 @@
 
 /// <reference path="./custom_typings/main.d.ts" />
 import * as cloneObject from 'clone';
-import {ASTNode as Node} from 'parse5';
+import {ASTNode as Node, treeAdapters} from 'parse5';
 export {ASTNode as Node} from 'parse5';
 
 function getAttributeIndex(element: Node, name: string): number {
@@ -312,20 +312,34 @@ export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
   return results;
 }
 
+export type childNodesRetriever = (node: Node) => Node[] | undefined;
+
+const defaultChildNodes: childNodesRetriever = node => node.childNodes;
+
+export const childNodesIncludeTemplate: childNodesRetriever = node => {
+  if (node.nodeName === 'template')
+    return treeAdapters.default.getTemplateContent(node).childNodes;
+  return node.childNodes;
+};
+
 /**
  * Walk the tree down from `node`, applying the `predicate` function.
  * Return the first node that matches the given predicate.
  *
  * @returns `null` if no node matches, parse5 node object if a node matches.
  */
-export function nodeWalk(node: Node, predicate: Predicate): Node|null {
+export function nodeWalk(
+    node: Node,
+    predicate: Predicate,
+    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node|null {
   if (predicate(node)) {
     return node;
   }
   let match: Node|null = null;
-  if (node.childNodes) {
-    for (let i = 0; i < node.childNodes.length; i++) {
-      match = nodeWalk(node.childNodes[i], predicate);
+  const childNodes = retrieveChildNodes(node);
+  if (childNodes) {
+    for (let i = 0; i < childNodes.length; i++) {
+      match = nodeWalk(childNodes[i], predicate, retrieveChildNodes);
       if (match) {
         break;
       }
@@ -340,29 +354,37 @@ export function nodeWalk(node: Node, predicate: Predicate): Node|null {
  * returned.
  */
 export function nodeWalkAll(
-    node: Node, predicate: Predicate, matches?: Node[]): Node[] {
+    node: Node,
+    predicate: Predicate,
+    matches?: Node[],
+    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node[] {
   if (!matches) {
     matches = [];
   }
   if (predicate(node)) {
     matches.push(node);
   }
-  if (node.childNodes) {
-    for (let i = 0; i < node.childNodes.length; i++) {
-      nodeWalkAll(node.childNodes[i], predicate, matches);
+  const childNodes = retrieveChildNodes(node);
+  if (childNodes) {
+    for (let i = 0; i < childNodes.length; i++) {
+      nodeWalkAll(childNodes[i], predicate, matches, retrieveChildNodes);
     }
   }
   return matches;
 }
 
 function _reverseNodeWalkAll(
-    node: Node, predicate: Predicate, matches: Node[]): Node[] {
+    node: Node,
+    predicate: Predicate,
+    matches: Node[],
+    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node[] {
   if (!matches) {
     matches = [];
   }
-  if (node.childNodes) {
-    for (let i = node.childNodes.length - 1; i >= 0; i--) {
-      nodeWalkAll(node.childNodes[i], predicate, matches);
+  const childNodes = retrieveChildNodes(node);
+  if (childNodes) {
+    for (let i = childNodes.length - 1; i >= 0; i--) {
+      nodeWalkAll(childNodes[i], predicate, matches, retrieveChildNodes);
     }
   }
   if (predicate(node)) {
@@ -450,18 +472,24 @@ export function nodeWalkAllPrior(
 /**
  * Equivalent to `nodeWalk`, but only matches elements
  */
-export function query(node: Node, predicate: Predicate): Node|null {
+export function query(
+    node: Node,
+    predicate: Predicate,
+    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node|null {
   const elementPredicate = AND(isElement, predicate);
-  return nodeWalk(node, elementPredicate);
+  return nodeWalk(node, elementPredicate, retrieveChildNodes);
 }
 
 /**
  * Equivalent to `nodeWalkAll`, but only matches elements
  */
 export function queryAll(
-    node: Node, predicate: Predicate, matches?: Node[]): Node[] {
+    node: Node,
+    predicate: Predicate,
+    matches?: Node[],
+    retrieveChildNodes: childNodesRetriever = defaultChildNodes): Node[] {
   const elementPredicate = AND(isElement, predicate);
-  return nodeWalkAll(node, elementPredicate, matches);
+  return nodeWalkAll(node, elementPredicate, matches, retrieveChildNodes);
 }
 
 function newTextNode(value: string): Node {

--- a/test/dom5_test.ts
+++ b/test/dom5_test.ts
@@ -563,10 +563,9 @@ suite('dom5', function() {
     });
 
     test('nodeWalkAncestors', function() {
+      doc = parse5.parse(docText.replace(/template/g, 'div'));
       // doc -> dom-module -> template -> a
-      const template = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
-      const anchor = parse5.treeAdapters.default.getTemplateContent(template)
-          .childNodes![3];
+      const anchor = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1].childNodes![3];
 
       assert(dom5.predicates.hasTagName('a')(anchor));
       const domModule =

--- a/test/dom5_test.ts
+++ b/test/dom5_test.ts
@@ -543,19 +543,22 @@ suite('dom5', function() {
   });
 
   suite('Query', function() {
-    const docText = [
-      '<!DOCTYPE html>',
-      '<link rel="import" href="polymer.html">',
-      '<dom-module id="my-el">',
-      '<template>',
-      '<img src="foo.jpg">',
-      '<a href="next-page.html">Anchor</a>',
-      'sample element',
-      '<!-- comment node -->',
-      '</template>',
-      '</dom-module>',
-      '<script>Polymer({is: "my-el"})</script>'
-    ].join('\n');
+    const docText: string = `
+<!DOCTYPE html>
+<link rel="import" href="polymer.html">
+<dom-module id="my-el">
+  <template>
+    <img src="foo.jpg">
+    <a href="next-page.html">Anchor</a>
+    sample element
+    <!-- comment node -->
+  </template>
+  <div>
+    <a href="another-anchor">Anchor2</a>
+  </div>
+</dom-module>
+<script>Polymer({is: "my-el"})</script>
+`.replace(/  /g, '');
     let doc: parse5.ASTNode;
 
     setup(function() {
@@ -563,9 +566,8 @@ suite('dom5', function() {
     });
 
     test('nodeWalkAncestors', function() {
-      doc = parse5.parse(docText.replace(/template/g, 'div'));
-      // doc -> dom-module -> template -> a
-      const anchor = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1].childNodes![3];
+      // doc -> dom-module -> div -> a
+      const anchor = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![3].childNodes![1];
 
       assert(dom5.predicates.hasTagName('a')(anchor));
       const domModule =
@@ -649,7 +651,7 @@ suite('dom5', function() {
       const expected_2 = templateContent.childNodes![3];
       const actual = dom5.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
 
-      assert.equal(actual.length, 2);
+      assert.equal(actual.length, 3);
       assert.equal(expected_1, actual[0]);
       assert.equal(expected_2, actual[1]);
     });

--- a/test/dom5_test.ts
+++ b/test/dom5_test.ts
@@ -547,12 +547,12 @@ suite('dom5', function() {
       '<!DOCTYPE html>',
       '<link rel="import" href="polymer.html">',
       '<dom-module id="my-el">',
-      '<div>', // TODO(justinfagnani): this used to be a template, we should test templates
+      '<template>',
       '<img src="foo.jpg">',
       '<a href="next-page.html">Anchor</a>',
       'sample element',
       '<!-- comment node -->',
-      '</div>',
+      '</template>',
       '</dom-module>',
       '<script>Polymer({is: "my-el"})</script>'
     ].join('\n');
@@ -563,9 +563,10 @@ suite('dom5', function() {
     });
 
     test('nodeWalkAncestors', function() {
-      // doc -> dom-module -> div -> a
-      const anchor = doc.childNodes![1].childNodes![1].childNodes![0]
-          .childNodes![1].childNodes![3];
+      // doc -> dom-module -> template -> a
+      const template = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      const anchor = parse5.treeAdapters.default.getTemplateContent(template)
+          .childNodes![3];
 
       assert(dom5.predicates.hasTagName('a')(anchor));
       const domModule =
@@ -579,8 +580,9 @@ suite('dom5', function() {
     });
 
     test('nodeWalk', function() {
-      // doc -> body -> dom-module -> div
-      const div = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      // doc -> body -> dom-module -> template
+      const template = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      const templateContent = parse5.treeAdapters.default.getTemplateContent(template);
 
       const textNode = dom5.predicates.AND(
         dom5.isTextNode,
@@ -588,13 +590,13 @@ suite('dom5', function() {
       );
 
       // 'sample element' text node
-      let expected = div.childNodes![4];
-      let actual = dom5.nodeWalk(doc, textNode);
+      let expected = templateContent.childNodes![4];
+      let actual = dom5.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
       assert.equal(expected, actual);
 
       // <!-- comment node -->
-      expected = div.childNodes![5];
-      actual = dom5.nodeWalk(div, dom5.isCommentNode);
+      expected = templateContent.childNodes![5];
+      actual = dom5.nodeWalk(template, dom5.isCommentNode, dom5.childNodesIncludeTemplate);
       assert.equal(expected, actual);
     });
 
@@ -622,7 +624,7 @@ suite('dom5', function() {
       // subtract one to get "gap" number
       const expected = serializedDoc.split('\n').length - 1;
       // add two for normalized text node "\nsample text\n"
-      const actual = dom5.nodeWalkAll(doc, empty).length + 2;
+      const actual = dom5.nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate).length + 2;
 
       assert.equal(expected, actual);
     });
@@ -638,14 +640,15 @@ suite('dom5', function() {
         )
       );
 
-      // doc -> body -> dom-module -> div
-      const div = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      // doc -> body -> dom-module -> template
+      const template = doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+      const templateContent = parse5.treeAdapters.default.getTemplateContent(template);
 
       // img
-      const expected_1 = div.childNodes![1];
+      const expected_1 = templateContent.childNodes![1];
       // anchor
-      const expected_2 = div.childNodes![3];
-      const actual = dom5.queryAll(doc, fn);
+      const expected_2 = templateContent.childNodes![3];
+      const actual = dom5.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
 
       assert.equal(actual.length, 2);
       assert.equal(expected_1, actual[0]);


### PR DESCRIPTION
Add an extra argument to the traversal methods to enable to traverse templates. An example usage of this argument is `dom5.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate)`. It adds an optional argument, which defaults to only retrieving `node.childNodes` and is therefore non-breaking. Users can therefore opt-in for the template traversal by passing `dom5.childNodesIncludeTemplate`. (happy to bike-shed on the name, couldn't come up with a better one).

Note that the tests currently fail, as there is a breaking change in the traversal of parentNodes. This is because a `#document-fragment` `AST.Node` in `parse5` does not have a `parentNode` value. E.g. it does not reference back to the `<template>` `AST.Node` that was its parent. I am not sure if we can request this to be added in `parse5`.

 - [x] CHANGELOG.md has been updated

Fixes #40

cc @rictic per our conversation yesterday