### PR TITLE
Added removeFakeNodes to dom5.

### DIFF
--- a/dom5.ts
+++ b/dom5.ts
@@ -605,6 +605,35 @@ export function remove(node: Node) {
   node.parentNode = undefined;
 }
 
+/**
+ * Removes a node and places its children in its place.  If the node
+ * has no parent, the operation is impossible and no action takes place.
+ */
+export function removeNodeSaveChildren(node: Node) {
+  // We can't save the children if there's no parent node to provide
+  // for them.
+  const fosterParent = node.parentNode;
+  if (!fosterParent) {
+    return;
+  }
+  const children = (node.childNodes || []).slice();
+  for (const child of children) {
+    insertBefore(node.parentNode!, node, child);
+  }
+  remove(node);
+}
+
+/**
+ * When parse5 parses an HTML document, it injects a few html tags
+ * (html, head and body) if they are missing.  This function removes
+ * nodes from the AST which have no location info, so it requires that the
+ * `parse5.parse` be used with the `locationInfo` option of `true`.
+ */
+export function removeFakeNodes(ast: Node) {
+  const injectedNodes = queryAll(ast, (node) => !node.__location);
+  injectedNodes.reverse().forEach(removeNodeSaveChildren);
+}
+
 export function insertBefore(parent: Node, oldNode: Node, newNode: Node) {
   const index = parent.childNodes!.indexOf(oldNode);
   insertNode(parent, index, newNode);

--- a/dom5.ts
+++ b/dom5.ts
@@ -632,7 +632,13 @@ export function removeNodeSaveChildren(node: Node) {
 export function removeFakeRootElements(ast: Node) {
   const injectedNodes = queryAll(
       ast,
-      (n) => !n.__location && hasMatchingTagName(/^(html|head|body)$/i)(n));
+      AND((node) => !node.__location,
+          hasMatchingTagName(/^(html|head|body)$/i)),
+      undefined,
+      // Don't descend past 3 levels 'document > html > head|body'
+      (node) => node.parentNode && node.parentNode.parentNode ?
+          undefined :
+          node.childNodes);
   injectedNodes.reverse().forEach(removeNodeSaveChildren);
 }
 

--- a/dom5.ts
+++ b/dom5.ts
@@ -624,13 +624,15 @@ export function removeNodeSaveChildren(node: Node) {
 }
 
 /**
- * When parse5 parses an HTML document, it injects a few html tags
- * (html, head and body) if they are missing.  This function removes
- * nodes from the AST which have no location info, so it requires that the
- * `parse5.parse` be used with the `locationInfo` option of `true`.
+ * When parse5 parses an HTML document with `parse`, it injects missing root
+ * elements (html, head and body) if they are missing.  This function removes
+ * these from the AST if they have no location info, so it requires that
+ * the `parse5.parse` be used with the `locationInfo` option of `true`.
  */
-export function removeFakeNodes(ast: Node) {
-  const injectedNodes = queryAll(ast, (node) => !node.__location);
+export function removeFakeRootElements(ast: Node) {
+  const injectedNodes = queryAll(
+      ast,
+      (n) => !n.__location && hasMatchingTagName(/^(html|head|body)$/i)(n));
   injectedNodes.reverse().forEach(removeNodeSaveChildren);
 }
 

--- a/test/dom5_test.ts
+++ b/test/dom5_test.ts
@@ -300,23 +300,23 @@ suite('dom5', function() {
       });
     });
 
-    suite('Remove fake nodes from tree', function() {
-      test('Fake nodes will be removed', function() {
+    suite('Remove fake root elements from tree', function() {
+      test('Fake root elements will be removed', function() {
         const html = `<div>Just a div</div>`;
         const ast = parse5.parse(html, {locationInfo: true});
         assert.deepEqual(
             parse5.serialize(ast),
             '<html><head></head><body><div>Just a div</div></body></html>');
-        dom5.removeFakeNodes(ast);
+        dom5.removeFakeRootElements(ast);
         assert.deepEqual(parse5.serialize(ast), html);
       });
 
-      test('Real nodes will be preserved', function() {
+      test('Real root elements will be preserved', function() {
         const html =
             '<html><head></head><body><div>Just a div</div></body></html>';
         const ast = parse5.parse(html, {locationInfo: true});
         assert.deepEqual(parse5.serialize(ast), html);
-        dom5.removeFakeNodes(ast);
+        dom5.removeFakeRootElements(ast);
         assert.deepEqual(parse5.serialize(ast), html);
       });
     });

--- a/test/dom5_test.ts
+++ b/test/dom5_test.ts
@@ -289,6 +289,38 @@ suite('dom5', function() {
       });
     });
 
+    suite('Remove node, save children', function() {
+      test('node is removed and children at same position', function() {
+        const html = '<div><em>x</em><span><em>a</em><em>c</em></span>y</div>';
+        const ast = parse5.parseFragment(html);
+        const span = ast.childNodes![0]!.childNodes![1]!;
+        dom5.removeNodeSaveChildren(span);
+        assert.deepEqual(parse5.serialize(ast),
+            '<div><em>x</em><em>a</em><em>c</em>y</div>');
+      });
+    });
+
+    suite('Remove fake nodes from tree', function() {
+      test('Fake nodes will be removed', function() {
+        const html = `<div>Just a div</div>`;
+        const ast = parse5.parse(html, {locationInfo: true});
+        assert.deepEqual(
+            parse5.serialize(ast),
+            '<html><head></head><body><div>Just a div</div></body></html>');
+        dom5.removeFakeNodes(ast);
+        assert.deepEqual(parse5.serialize(ast), html);
+      });
+
+      test('Real nodes will be preserved', function() {
+        const html =
+            '<html><head></head><body><div>Just a div</div></body></html>';
+        const ast = parse5.parse(html, {locationInfo: true});
+        assert.deepEqual(parse5.serialize(ast), html);
+        dom5.removeFakeNodes(ast);
+        assert.deepEqual(parse5.serialize(ast), html);
+      });
+    });
+
     suite('Append Node', function() {
       let dom: parse5.ASTNode, div: parse5.ASTNode, span: parse5.ASTNode;
 


### PR DESCRIPTION
This version of `removeFakeNodes` is very very paired down and actually only cares if a node has no `__locationInfo` and nothing else, really.
