### PR TITLE
Update parse5 typings to remove custom_typings

### DIFF
--- a/custom_typings/main.d.ts
+++ b/custom_typings/main.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="parse5.d.ts" />

--- a/custom_typings/parse5.d.ts
+++ b/custom_typings/parse5.d.ts
@@ -1,7 +1,0 @@
-import {ASTNode} from 'parse5';
-
-declare module 'parse5' {
-  // TODO(fks) 11-01-2016: Remove this once @types/parse5 includes `tagName`
-  // (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12424)
-  export interface ASTNode { tagName?: string; }
-}

--- a/dom5.ts
+++ b/dom5.ts
@@ -12,7 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-/// <reference path="./custom_typings/main.d.ts" />
 import * as cloneObject from 'clone';
 import {ASTNode as Node, treeAdapters} from 'parse5';
 export {ASTNode as Node} from 'parse5';
@@ -312,7 +311,7 @@ export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
   return results;
 }
 
-export type GetChildNodes = (node: Node) => Node[] | undefined;
+export type GetChildNodes = (node: Node) => Node[]|undefined;
 
 export const defaultChildNodes: GetChildNodes = node => node.childNodes;
 


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/12424 has been merged, so the custom typings can be removed :tada: 

 - [x] CHANGELOG.md has not been updated, internal change
