### PR TITLE
 Rewrite walking functions in terms of iteration. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 sudo: false
 node_js:
   - "6"
-  - "4"
+  - "8"
+  - "node"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "test:watch",
+      "isBackground": true,
+      "presentation": {
+        "echo": false,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated"
+      },
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "promptOnClose": false,
+      "problemMatcher": {
+        "fileLocation": [
+          "relative",
+          "${workspaceRoot}/src"
+        ],
+        "background": {
+          "beginsPattern": "tsc-then: Running",
+          "endsPattern": "tsc-then: command finished"
+        },
+        "pattern": [
+          {
+            "regexp": "^  (\\d+)\\) ((\\w+).*)",
+            "message": 2,
+            "file": 3,
+            "line": 1,
+            "column": 1
+          }
+        ],
+        "applyTo": "allDocuments",
+        "severity": "error"
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] Update to parse5 v4. For breaking changes see:
   - http://inikulin.github.io/parse5/#4-0-0 and
     http://inikulin.github.io/parse5/#3-0-0
+- [BREAKING] Split out the functions for walking the dom into `dom5.walking`.
+  So `dom5.nodeWalkAll` becomes `dom5.walking.nodeWalkAll`. These functions are
+  deprecated in favor of the faster and more flexible functions in
+  `dom5.iteration`. more easily track down and remove uses of them.
+- [BREAKING] Minimum supported version of node updated to v6 or above.
 - Moved development-only dependencies in package.json to devDependencies.
 <!-- Add new, unreleased changes here. -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- [BREAKING] Update to parse5 v4. For breaking changes see:
+- [BREAKING] Updated to parse5 v4. See:
   - http://inikulin.github.io/parse5/#4-0-0 and
     http://inikulin.github.io/parse5/#3-0-0
-- [BREAKING] Split out the functions for walking the dom into `dom5.walking`.
-  So `dom5.nodeWalkAll` becomes `dom5.walking.nodeWalkAll`. These functions are
-  deprecated in favor of the faster and more flexible functions in
-  `dom5.iteration`. more easily track down and remove uses of them.
+  - Most users will not be affected by these changes.
 - [BREAKING] Minimum supported version of node updated to v6 or above.
+- [Upcoming breaking change] We've redesigned our DOM walking API around
+  iteration rather than callbacks. Import `'dom5/lib/index-next.js'` to receive
+  the new API. This will be the API exposed in the next major version.
+  Specifically, the `nodeWalk`, `nodeWalkAll`, `nodeWalkPrior`,
+  `nodeWalkAllPrior`, and `nodeWalkAncestors` APIs are replaced by `depthFirst`,
+  `prior`, and `ancestors` APIs, which simply iterators now. In addition
+  `queryAll` will return an iterator rather than an array.
 - Moved development-only dependencies in package.json to devDependencies.
 <!-- Add new, unreleased changes here. -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -980,6 +980,24 @@
       "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
+    "tsc-then": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsc-then/-/tsc-then-1.1.0.tgz",
+      "integrity": "sha512-830G8SK8tewOxfKVBC5YWqZ2C7wS1D4dh9267ebLxR7Gvh3UuI6aKU5Hxo+L3Kkcy6CuxZp4PMGl066DZ3Hlmw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.9.3",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+          "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
+          "dev": true
+        }
+      }
+    },
     "tslint": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepublish": "npm run test",
     "test": "npm run build && npm run lint && mocha --ui tdd lib/test/*.js",
     "format": "./node_modules/.bin/clang-format --style=file -i dom5.ts test/dom5_test.ts",
-    "lint": "tslint dom5.ts"
+    "lint": "tslint dom5.ts",
+    "test:watch": "tsc-then -- mocha -c --ui tdd lib/test/*.js"
   },
   "dependencies": {
     "@types/parse5": "^2.2.32",
@@ -28,6 +29,7 @@
     "chai": "^3.3.0",
     "clang-format": "=1.0.49",
     "mocha": "^2.0.1",
+    "tsc-then": "^1.1.0",
     "tslint": "^4.0.0",
     "typescript": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "npm run test",
-    "test": "npm run build && npm run lint && mocha --ui tdd lib/test/*.js",
+    "test": "npm run build && npm run lint && mocha -c --ui tdd 'lib/test/*_test.js'",
     "format": "./node_modules/.bin/clang-format --style=file -i dom5.ts test/dom5_test.ts",
     "lint": "tslint dom5.ts",
-    "test:watch": "tsc-then -- mocha -c --ui tdd lib/test/*.js"
+    "test:watch": "tsc-then -- mocha -c --ui tdd 'lib/test/*_test.js'"
   },
   "dependencies": {
     "@types/parse5": "^2.2.32",

--- a/src/index-next.ts
+++ b/src/index-next.ts
@@ -11,7 +11,14 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+
+// This is the API that we would like to expose.
+//
+// We can change users to import this file directly, then
+// we can do a breaking change that replaces the contents
+// of index.ts with this.
+
 export * from './modification';
 export * from './predicates';
 export * from './util';
-export * from './walking';
+export * from './iteration';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,4 +14,8 @@
 export * from './modification';
 export * from './predicates';
 export * from './util';
-export * from './walking';
+import * as _walking from './walking';
+import * as _iteration from './iteration';
+
+export const iteration = _iteration;
+export const walking = _walking;

--- a/src/iteration.ts
+++ b/src/iteration.ts
@@ -37,7 +37,7 @@ export function*
 /**
  * Yields `node` and all of its children, recursively.
  *
- * Yields `node` first, yields emits each descendent in depth first order.
+ * Yields `node` first, then yields each descendent in depth first order.
  */
 export function*
     depthFirst(node: Node, getChildNodes: GetChildNodes = defaultChildNodes):

--- a/src/iteration.ts
+++ b/src/iteration.ts
@@ -35,7 +35,7 @@ export function*
 
 
 /**
- * Iterates over the `node` and all of its children, recursively.
+ * Yields `node` and all of its children, recursively.
  *
  * Yields `node` first, yields emits each descendent in depth first order.
  */
@@ -52,6 +52,12 @@ export function*
   }
 }
 
+/**
+ * Yields node and all its descendents in reverse document order.
+ *
+ * Equivalent to:
+ *    yield* [...depthFirst(node)].reverse()
+ */
 export function*
     depthFirstReversed(
         node: Node, getChildNodes: GetChildNodes = defaultChildNodes):
@@ -111,6 +117,40 @@ export function* previousSiblings(node: Node): IterableIterator<Node> {
 function* reversedView<U>(arr: U[], initialIndex = arr.length - 1) {
   for (let index = initialIndex; index >= 0; index--) {
     yield arr[index];
+  }
+}
+
+/**
+ * Yields every node in the document that comes before `node`, in reverse
+ * document order.
+ *
+ * So if you have a tree like:
+ * ```html
+ *   <body>
+ *     <nav>
+ *       <li></li>
+ *     </nav>
+ *     <div>
+ *       <span></span>
+ *       <b></b>
+ *       <em></em>
+ *       ...
+ * ```
+ *
+ * Then `prior(<b>)` will yield:
+ *
+ *     <span>, <div>, <li>, <nav>, <body>, <head>, #document
+ *
+ * (`<head>` and `#document` are hallucinated by the html parser)
+ */
+export function* prior(node: Node): IterableIterator<Node> {
+  for (const previousSibling of previousSiblings(node)) {
+    yield* depthFirstReversed(previousSibling);
+  }
+  const parent = node.parentNode;
+  if (parent) {
+    yield parent;
+    yield* prior(parent);
   }
 }
 

--- a/src/iteration.ts
+++ b/src/iteration.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {ASTNode as Node, ASTNode, treeAdapters} from 'parse5';
+export {ASTNode as Node} from 'parse5';
+
+/**
+ * Applies `mapfn` to `node` and the tree below `node`, yielding a flattened
+ * list of results.
+ */
+export function*
+    treeMap<U>(
+        node: Node,
+        mapfn: (node: Node) => Iterable<U>,
+        getChildNodes?: GetChildNodes): IterableIterator<U> {
+  for (const child of depthFirst(node, getChildNodes)) {
+    yield* mapfn(child);
+  };
+}
+
+export type GetChildNodes = ((node: Node) => Node[] | undefined);
+
+export const defaultChildNodes = function defaultChildNodes(node: ASTNode) {
+  return node.childNodes;
+};
+
+export const childNodesIncludeTemplate = function childNodesIncludeTemplate(
+    node: ASTNode) {
+  if (node.nodeName === 'template') {
+    return treeAdapters.default.getTemplateContent(node).childNodes;
+  }
+
+  return node.childNodes;
+};
+
+/**
+ * Iterates over the `node` and all of its children, recursively.
+ *
+ * Yields `node` first, yields emits each descendent in depth first order.
+ */
+export function*
+    depthFirst(node: Node, getChildNodes: GetChildNodes = defaultChildNodes):
+        IterableIterator<Node> {
+  yield node;
+  const childNodes = getChildNodes(node);
+  if (childNodes === undefined) {
+    return;
+  }
+  for (const child of childNodes) {
+    yield* depthFirst(child, getChildNodes);
+  }
+}
+
+export function*
+    depthFirstReversed(
+        node: Node, getChildNodes: GetChildNodes = defaultChildNodes):
+        IterableIterator<Node> {
+  const childNodes = getChildNodes(node);
+  if (childNodes !== undefined) {
+    for (const child of reversedView(childNodes)) {
+      yield* depthFirstReversed(child, getChildNodes);
+    }
+  }
+  yield node;
+}
+
+/**
+ * Like `depthFirst`, but descends into the bodies of `<template>`s.
+ */
+export function depthFirstIncludingTemplates(node: Node) {
+  return depthFirst(node, childNodesIncludeTemplate);
+}
+
+/**
+ * Yields `node` and each of its ancestors leading up the tree.
+ */
+export function* ancestors(node: Node): IterableIterator<Node> {
+  let currNode: Node|undefined = node;
+  while (currNode !== undefined) {
+    yield currNode;
+    currNode = currNode.parentNode;
+  }
+}
+
+/**
+ * Yields each element that has the same parent as `node` but that
+ * comes before it in the document.
+ *
+ * Nodes are yielded in reverse document order (i.e. starting with the one
+ * closest to `node`)
+ */
+export function* previousSiblings(node: Node): IterableIterator<Node> {
+  const parent = node.parentNode;
+  if (parent === undefined) {
+    return;
+  }
+  const siblings = parent.childNodes;
+  if (siblings === undefined) {
+    throw new Error(`Inconsistent parse5 tree: parent does not have children`);
+  }
+  const index = siblings.indexOf(node);
+  if (index === -1) {
+    throw new Error(
+        `Inconsistent parse5 tree: parent does not know about child`);
+  }
+  yield* reversedView(siblings, index - 1);
+}
+
+/** Iterate arr in reverse, optionally starting at a given index. */
+function* reversedView<U>(arr: U[], initialIndex = arr.length - 1) {
+  for (let index = initialIndex; index >= 0; index--) {
+    yield arr[index];
+  }
+}
+
+// function _reverseNodeWalkAll(
+//     node: Node,
+//     predicate: Predicate,
+//     matches: Node[],
+//     getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
+//   if (!matches) {
+//     matches = [];
+//   }
+//   const childNodes = getChildNodes(node);
+//   if (childNodes) {
+//     for (let i = childNodes.length - 1; i >= 0; i--) {
+//       nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
+//     }
+//   }
+//   if (predicate(node)) {
+//     matches.push(node);
+//   }
+//   return matches;
+// }
+
+// /**
+//  * Equivalent to `nodeWalk`, but only returns nodes that are either
+//  * ancestors or earlier cousins/siblings in the document.
+//  *
+//  * Nodes are searched in reverse document order, starting from the sibling
+//  * prior to `node`.
+//  */
+// export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
+//     undefined {
+//   // Search our earlier siblings and their descendents.
+//   const parent = node.parentNode;
+//   if (parent && parent.childNodes) {
+//     const idx = parent.childNodes.indexOf(node);
+//     const siblings = parent.childNodes.slice(0, idx);
+//     for (let i = siblings.length - 1; i >= 0; i--) {
+//       const sibling = siblings[i];
+//       if (predicate(sibling)) {
+//         return sibling;
+//       }
+//       const found = nodeWalk(sibling, predicate);
+//       if (found) {
+//         return found;
+//       }
+//     }
+//     if (predicate(parent)) {
+//       return parent;
+//     }
+//     return nodeWalkPrior(parent, predicate);
+//   }
+//   return undefined;
+// }
+
+// /**
+//  * Walk the tree up from the parent of `node`, to its grandparent and so on
+//  to * the root of the tree.  Return the first ancestor that matches the given
+//  * predicate.
+//  */
+// export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
+//     undefined {
+//   const parent = node.parentNode;
+//   if (!parent) {
+//     return undefined;
+//   }
+//   if (predicate(parent)) {
+//     return parent;
+//   }
+//   return nodeWalkAncestors(parent, predicate);
+// }
+
+// /**
+//  * Equivalent to `nodeWalkAll`, but only returns nodes that are either
+//  * ancestors or earlier cousins/siblings in the document.
+//  *
+//  * Nodes are returned in reverse document order, starting from `node`.
+//  */
+// export function nodeWalkAllPrior(
+//     node: Node, predicate: Predicate, matches?: Node[]): Node[] {
+//   if (!matches) {
+//     matches = [];
+//   }
+//   if (predicate(node)) {
+//     matches.push(node);
+//   }
+//   // Search our earlier siblings and their descendents.
+//   const parent = node.parentNode;
+//   if (parent) {
+//     const idx = parent.childNodes!.indexOf(node);
+//     const siblings = parent.childNodes!.slice(0, idx);
+//     for (let i = siblings.length - 1; i >= 0; i--) {
+//       _reverseNodeWalkAll(siblings[i], predicate, matches);
+//     }
+//     nodeWalkAllPrior(parent, predicate, matches);
+//   }
+//   return matches;
+// }
+
+// /**
+//  * Equivalent to `nodeWalk`, but only matches elements
+//  */
+// export function query(
+//     node: Node,
+//     predicate: Predicate,
+//     getChildNodes: GetChildNodes = defaultChildNodes): Node|null {
+//   const elementPredicate = p.AND(isElement, predicate);
+//   return nodeWalk(node, elementPredicate, getChildNodes);
+// }
+
+// /**
+//  * Equivalent to `nodeWalkAll`, but only matches elements
+//  */
+// export function queryAll(
+//     node: Node,
+//     predicate: Predicate,
+//     matches?: Node[],
+//     getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
+//   const elementPredicate = p.AND(isElement, predicate);
+//   return nodeWalkAll(node, elementPredicate, matches, getChildNodes);
+// }

--- a/src/modification.ts
+++ b/src/modification.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at

--- a/src/test/dom5_test.ts
+++ b/src/test/dom5_test.ts
@@ -14,7 +14,7 @@ import * as parse5 from 'parse5';
 
 import * as dom5 from '../index';
 
-/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="mocha" />
 
 suite('dom5', () => {
 

--- a/src/test/dom5_test.ts
+++ b/src/test/dom5_test.ts
@@ -583,21 +583,21 @@ suite('dom5', () => {
       const node = dom5.constructors.text('test');
       assert.isTrue(dom5.isTextNode(node));
       const fn = dom5.predicates.hasTextValue('test');
-      assert.equal(dom5.walking.nodeWalk(node, fn), node);
+      assert.equal(dom5.nodeWalk(node, fn), node);
     });
 
     test('comment node', () => {
       const node = dom5.constructors.comment('test');
       assert.isTrue(dom5.isCommentNode(node));
       const fn = dom5.predicates.hasTextValue('test');
-      assert.equal(dom5.walking.nodeWalk(node, fn), node);
+      assert.equal(dom5.nodeWalk(node, fn), node);
     });
 
     test('element', () => {
       const node = dom5.constructors.element('div');
       assert.isTrue(dom5.isElement(node));
       const fn = dom5.predicates.hasTagName('div');
-      assert.equal(dom5.walking.query(node, fn), node);
+      assert.equal(dom5.query(node, fn), node);
     });
   });
 

--- a/src/test/dom5_test.ts
+++ b/src/test/dom5_test.ts
@@ -612,11 +612,11 @@ suite('dom5', () => {
                          .childNodes![1];
 
       assert(dom5.predicates.hasTagName('a')(anchor));
-      const domModule = dom5.nodeWalkAncestors(
+      const domModule = dom5.walking.nodeWalkAncestors(
           anchor, dom5.predicates.hasTagName('dom-module'));
       assert(domModule);
-      const theLinkIsNotAnAncestor =
-          dom5.nodeWalkAncestors(anchor, dom5.predicates.hasTagName('link'));
+      const theLinkIsNotAnAncestor = dom5.walking.nodeWalkAncestors(
+          anchor, dom5.predicates.hasTagName('link'));
       assert.equal(theLinkIsNotAnAncestor, undefined);
     });
 
@@ -632,12 +632,13 @@ suite('dom5', () => {
 
       // 'sample element' text node
       let expected = templateContent.childNodes![4];
-      let actual = dom5.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
+      let actual =
+          dom5.walking.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
       assert.equal(actual, expected);
 
       // <!-- comment node -->
       expected = templateContent.childNodes![5];
-      actual = dom5.nodeWalk(
+      actual = dom5.walking.nodeWalk(
           template, dom5.isCommentNode, dom5.childNodesIncludeTemplate);
       assert.equal(actual, expected);
     });
@@ -648,7 +649,7 @@ suite('dom5', () => {
           dom5.predicates.hasAttrValue('rel', 'import'),
           dom5.predicates.hasAttr('href'));
       const expected = doc.childNodes![1].childNodes![0].childNodes![0];
-      const actual = dom5.query(doc, fn);
+      const actual = dom5.walking.query(doc, fn);
       assert.equal(actual, expected);
     });
 
@@ -663,7 +664,8 @@ suite('dom5', () => {
       const expected = serializedDoc.split('\n').length - 1;
       // add two for normalized text node "\nsample text\n"
       const actual =
-          dom5.nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate)
+          dom5.walking
+              .nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate)
               .length +
           2;
 
@@ -686,7 +688,8 @@ suite('dom5', () => {
       const expected_1 = templateContent.childNodes![1];
       // anchor
       const expected_2 = templateContent.childNodes![3];
-      const actual = dom5.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
+      const actual =
+          dom5.walking.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
 
       assert.equal(actual.length, 3);
       assert.equal(actual[0], expected_1);
@@ -704,9 +707,10 @@ suite('dom5', () => {
     });
 
     test('nodeWalkAllPrior', () => {
-      const domModule = dom5.nodeWalkAll(
+      const domModule = dom5.walking.nodeWalkAll(
           doc, dom5.predicates.hasAttrValue('id', 'test-element'))[0];
-      const comments = dom5.nodeWalkAllPrior(domModule, dom5.isCommentNode);
+      const comments =
+          dom5.walking.nodeWalkAllPrior(domModule, dom5.isCommentNode);
       assert.include(dom5.getTextContent(comments[0]), 'test element');
       assert.include(
           dom5.getTextContent(comments[1]), 'hash or path based routing');
@@ -724,21 +728,21 @@ suite('dom5', () => {
       const node = dom5.constructors.text('test');
       assert.isTrue(dom5.isTextNode(node));
       const fn = dom5.predicates.hasTextValue('test');
-      assert.equal(dom5.nodeWalk(node, fn), node);
+      assert.equal(dom5.walking.nodeWalk(node, fn), node);
     });
 
     test('comment node', () => {
       const node = dom5.constructors.comment('test');
       assert.isTrue(dom5.isCommentNode(node));
       const fn = dom5.predicates.hasTextValue('test');
-      assert.equal(dom5.nodeWalk(node, fn), node);
+      assert.equal(dom5.walking.nodeWalk(node, fn), node);
     });
 
     test('element', () => {
       const node = dom5.constructors.element('div');
       assert.isTrue(dom5.isElement(node));
       const fn = dom5.predicates.hasTagName('div');
-      assert.equal(dom5.query(node, fn), node);
+      assert.equal(dom5.walking.query(node, fn), node);
     });
   });
 

--- a/src/test/dom5_test.ts
+++ b/src/test/dom5_test.ts
@@ -9,17 +9,12 @@
  * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
-
-import * as chai from 'chai';
-import * as fs from 'fs';
+import {assert} from 'chai';
 import * as parse5 from 'parse5';
-import * as path from 'path';
 
 import * as dom5 from '../index';
-import {fixturesDir} from './utils';
 
-const assert = chai.assert;
+/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 
 suite('dom5', () => {
 
@@ -580,147 +575,7 @@ suite('dom5', () => {
     });
   });
 
-  suite('Query', () => {
-    const docText: string = `
-<!DOCTYPE html>
-<link rel="import" href="polymer.html">
-<dom-module id="my-el">
-  <template>
-    <img src="foo.jpg">
-    <a href="next-page.html">Anchor</a>
-    sample element
-    <!-- comment node -->
-  </template>
-  <div>
-    <a href="another-anchor">Anchor2</a>
-  </div>
-</dom-module>
-<script>Polymer({is: "my-el"})</script>
-`.replace(/  /g, '');
-    let doc: parse5.ASTNode;
 
-    setup(() => {
-      doc = parse5.parse(docText);
-    });
-
-    test('nodeWalkAncestors', () => {
-      // doc -> dom-module -> div -> a
-      const anchor = doc.childNodes![1]
-                         .childNodes![1]
-                         .childNodes![0]
-                         .childNodes![3]
-                         .childNodes![1];
-
-      assert(dom5.predicates.hasTagName('a')(anchor));
-      const domModule = dom5.walking.nodeWalkAncestors(
-          anchor, dom5.predicates.hasTagName('dom-module'));
-      assert(domModule);
-      const theLinkIsNotAnAncestor = dom5.walking.nodeWalkAncestors(
-          anchor, dom5.predicates.hasTagName('link'));
-      assert.equal(theLinkIsNotAnAncestor, undefined);
-    });
-
-    test('nodeWalk', () => {
-      // doc -> body -> dom-module -> template
-      const template =
-          doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
-      const templateContent =
-          parse5.treeAdapters.default.getTemplateContent(template);
-
-      const textNode = dom5.predicates.AND(
-          dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
-
-      // 'sample element' text node
-      let expected = templateContent.childNodes![4];
-      let actual =
-          dom5.walking.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
-      assert.equal(actual, expected);
-
-      // <!-- comment node -->
-      expected = templateContent.childNodes![5];
-      actual = dom5.walking.nodeWalk(
-          template, dom5.isCommentNode, dom5.childNodesIncludeTemplate);
-      assert.equal(actual, expected);
-    });
-
-    test('query', () => {
-      const fn = dom5.predicates.AND(
-          dom5.predicates.hasTagName('link'),
-          dom5.predicates.hasAttrValue('rel', 'import'),
-          dom5.predicates.hasAttr('href'));
-      const expected = doc.childNodes![1].childNodes![0].childNodes![0];
-      const actual = dom5.walking.query(doc, fn);
-      assert.equal(actual, expected);
-    });
-
-    test('nodeWalkAll', () => {
-      const empty = dom5.predicates.AND(dom5.isTextNode, function(node) {
-        return !/\S/.test(node.value!);
-      });
-
-      // serialize to count for inserted <head> and <body>
-      const serializedDoc = parse5.serialize(doc);
-      // subtract one to get "gap" number
-      const expected = serializedDoc.split('\n').length - 1;
-      // add two for normalized text node "\nsample text\n"
-      const actual =
-          dom5.walking
-              .nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate)
-              .length +
-          2;
-
-      assert.equal(actual, expected);
-    });
-
-    test('queryAll', () => {
-      const fn = dom5.predicates.AND(
-          dom5.predicates.OR(
-              dom5.predicates.hasAttr('href'), dom5.predicates.hasAttr('src')),
-          dom5.predicates.NOT(dom5.predicates.hasTagName('link')));
-
-      // doc -> body -> dom-module -> template
-      const template =
-          doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
-      const templateContent =
-          parse5.treeAdapters.default.getTemplateContent(template);
-
-      // img
-      const expected_1 = templateContent.childNodes![1];
-      // anchor
-      const expected_2 = templateContent.childNodes![3];
-      const actual =
-          dom5.walking.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
-
-      assert.equal(actual.length, 3);
-      assert.equal(actual[0], expected_1);
-      assert.equal(actual[1], expected_2);
-    });
-  });
-
-  suite('NodeWalkAllPrior', () => {
-    const docText = fs.readFileSync(
-        path.join(fixturesDir, 'multiple-comments.html'), 'utf8');
-    let doc: parse5.ASTNode;
-
-    setup(() => {
-      doc = parse5.parse(docText);
-    });
-
-    test('nodeWalkAllPrior', () => {
-      const domModule = dom5.walking.nodeWalkAll(
-          doc, dom5.predicates.hasAttrValue('id', 'test-element'))[0];
-      const comments =
-          dom5.walking.nodeWalkAllPrior(domModule, dom5.isCommentNode);
-      assert.include(dom5.getTextContent(comments[0]), 'test element');
-      assert.include(
-          dom5.getTextContent(comments[1]), 'hash or path based routing');
-      assert.include(
-          dom5.getTextContent(comments[2]), 'core-route-selectable.html');
-      assert.include(
-          dom5.getTextContent(comments[comments.length - 1]),
-          'The Polymer Project Authors');
-    });
-  });
 
   suite('Constructors', () => {
 

--- a/src/test/iteration_test.ts
+++ b/src/test/iteration_test.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as fs from 'fs';
+import * as parse5 from 'parse5';
+import * as path from 'path';
+
+import * as dom5 from '../index';
+import {fixturesDir} from './utils';
+
+/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
+
+suite('iteration', () => {
+  const docText: string = `
+<!DOCTYPE html>
+<link rel="import" href="polymer.html">
+<dom-module id="my-el">
+<template>
+  <img src="foo.jpg">
+  <a href="next-page.html">Anchor</a>
+  sample element
+  <!-- comment node -->
+</template>
+<div>
+  <a href="another-anchor">Anchor2</a>
+</div>
+</dom-module>
+<script>Polymer({is: "my-el"})</script>
+`.replace(/  /g, '');
+  let doc: parse5.ASTNode;
+
+  setup(() => {
+    doc = parse5.parse(docText);
+  });
+
+  test('ancestors', () => {
+    // doc -> dom-module -> div -> a
+    const anchor = doc.childNodes![1]
+                       .childNodes![1]
+                       .childNodes![0]
+                       .childNodes![3]
+                       .childNodes![1];
+
+    assert(dom5.predicates.hasTagName('a')(anchor));
+    const domModule = [...dom5.iteration.ancestors(anchor)].filter(
+        dom5.predicates.hasTagName('dom-module'))[0];
+    assert(domModule);
+    const theLinkIsNotAnAncestor = [...dom5.iteration.ancestors(anchor)].filter(
+        dom5.predicates.hasTagName('link'))[0];
+    assert.equal(theLinkIsNotAnAncestor, undefined);
+  });
+
+  test('depthFirst can be filtered down to one node', () => {
+    // doc -> body -> dom-module -> template
+    const template =
+        doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+    const templateContent =
+        parse5.treeAdapters.default.getTemplateContent(template);
+
+    const textNode = dom5.predicates.AND(
+        dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
+
+    // 'sample element' text node
+    let expected = templateContent.childNodes![4];
+    let actual = [
+      ...dom5.iteration.depthFirst(doc, dom5.childNodesIncludeTemplate)
+    ].filter(textNode)[0];
+    assert.equal(actual, expected);
+
+    // <!-- comment node -->
+    expected = templateContent.childNodes![5];
+    actual = [
+      ...dom5.iteration.depthFirst(template, dom5.childNodesIncludeTemplate)
+    ].filter(dom5.isCommentNode)[0];
+    assert.equal(actual, expected);
+  });
+
+  test('query', () => {
+    const fn = dom5.predicates.AND(
+        dom5.predicates.hasTagName('link'),
+        dom5.predicates.hasAttrValue('rel', 'import'),
+        dom5.predicates.hasAttr('href'));
+    const expected = doc.childNodes![1].childNodes![0].childNodes![0];
+    const actual = dom5.iteration.query(doc, fn);
+    assert.equal(actual, expected);
+  });
+
+  test('depthFirst yields all nodes inside', () => {
+    const empty = dom5.predicates.AND(dom5.isTextNode, function(node) {
+      return !/\S/.test(node.value!);
+    });
+
+    // serialize to count for inserted <head> and <body>
+    const serializedDoc = parse5.serialize(doc);
+    // subtract one to get "gap" number
+    const expected = serializedDoc.split('\n').length - 1;
+    // add two for normalized text node "\nsample text\n"
+    const actual =
+        [...dom5.iteration.depthFirst(doc, dom5.childNodesIncludeTemplate)]
+            .filter(empty)
+            .length +
+        2;
+
+    assert.equal(actual, expected);
+  });
+
+  test('queryAll', () => {
+    const fn = dom5.predicates.AND(
+        dom5.predicates.OR(
+            dom5.predicates.hasAttr('href'), dom5.predicates.hasAttr('src')),
+        dom5.predicates.NOT(dom5.predicates.hasTagName('link')));
+
+    // doc -> body -> dom-module -> template
+    const template =
+        doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+    const templateContent =
+        parse5.treeAdapters.default.getTemplateContent(template);
+
+    // img
+    const expected_1 = templateContent.childNodes![1];
+    // anchor
+    const expected_2 = templateContent.childNodes![3];
+    const actual =
+        [...dom5.iteration.queryAll(doc, fn, dom5.childNodesIncludeTemplate)];
+
+    assert.equal(actual.length, 3);
+    assert.equal(actual[0], expected_1);
+    assert.equal(actual[1], expected_2);
+  });
+
+  suite('prior', () => {
+    const docText = fs.readFileSync(
+        path.join(fixturesDir, 'multiple-comments.html'), 'utf8');
+    let doc: parse5.ASTNode;
+
+    setup(() => {
+      doc = parse5.parse(docText);
+    });
+
+    test('prior', () => {
+      const domModule = dom5.iteration.query(
+          doc, dom5.predicates.hasAttrValue('id', 'test-element'))!;
+      const comments =
+          [...dom5.iteration.prior(domModule)].filter(dom5.isCommentNode);
+      assert.include(dom5.getTextContent(comments[0]), 'test element');
+      assert.include(
+          dom5.getTextContent(comments[1]), 'hash or path based routing');
+      assert.include(
+          dom5.getTextContent(comments[2]), 'core-route-selectable.html');
+      assert.include(
+          dom5.getTextContent(comments[comments.length - 1]),
+          'The Polymer Project Authors');
+    });
+  });
+});

--- a/src/test/iteration_test.ts
+++ b/src/test/iteration_test.ts
@@ -14,7 +14,7 @@ import * as fs from 'fs';
 import * as parse5 from 'parse5';
 import * as path from 'path';
 
-import * as dom5 from '../index';
+import * as dom5 from '../index-next';
 import {fixturesDir} from './utils';
 
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
@@ -51,10 +51,10 @@ suite('iteration', () => {
                        .childNodes![1];
 
     assert(dom5.predicates.hasTagName('a')(anchor));
-    const domModule = [...dom5.iteration.ancestors(anchor)].filter(
+    const domModule = [...dom5.ancestors(anchor)].filter(
         dom5.predicates.hasTagName('dom-module'))[0];
     assert(domModule);
-    const theLinkIsNotAnAncestor = [...dom5.iteration.ancestors(anchor)].filter(
+    const theLinkIsNotAnAncestor = [...dom5.ancestors(anchor)].filter(
         dom5.predicates.hasTagName('link'))[0];
     assert.equal(theLinkIsNotAnAncestor, undefined);
   });
@@ -71,16 +71,16 @@ suite('iteration', () => {
 
     // 'sample element' text node
     let expected = templateContent.childNodes![4];
-    let actual = [
-      ...dom5.iteration.depthFirst(doc, dom5.childNodesIncludeTemplate)
-    ].filter(textNode)[0];
+    let actual =
+        [...dom5.depthFirst(doc, dom5.childNodesIncludeTemplate)].filter(
+            textNode)[0];
     assert.equal(actual, expected);
 
     // <!-- comment node -->
     expected = templateContent.childNodes![5];
-    actual = [
-      ...dom5.iteration.depthFirst(template, dom5.childNodesIncludeTemplate)
-    ].filter(dom5.isCommentNode)[0];
+    actual =
+        [...dom5.depthFirst(template, dom5.childNodesIncludeTemplate)].filter(
+            dom5.isCommentNode)[0];
     assert.equal(actual, expected);
   });
 
@@ -90,7 +90,7 @@ suite('iteration', () => {
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
     const expected = doc.childNodes![1].childNodes![0].childNodes![0];
-    const actual = dom5.iteration.query(doc, fn);
+    const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
 
@@ -104,10 +104,9 @@ suite('iteration', () => {
     // subtract one to get "gap" number
     const expected = serializedDoc.split('\n').length - 1;
     // add two for normalized text node "\nsample text\n"
-    const actual =
-        [...dom5.iteration.depthFirst(doc, dom5.childNodesIncludeTemplate)]
-            .filter(empty)
-            .length +
+    const actual = [...dom5.depthFirst(doc, dom5.childNodesIncludeTemplate)]
+                       .filter(empty)
+                       .length +
         2;
 
     assert.equal(actual, expected);
@@ -129,8 +128,7 @@ suite('iteration', () => {
     const expected_1 = templateContent.childNodes![1];
     // anchor
     const expected_2 = templateContent.childNodes![3];
-    const actual =
-        [...dom5.iteration.queryAll(doc, fn, dom5.childNodesIncludeTemplate)];
+    const actual = [...dom5.queryAll(doc, fn, dom5.childNodesIncludeTemplate)];
 
     assert.equal(actual.length, 3);
     assert.equal(actual[0], expected_1);
@@ -147,10 +145,9 @@ suite('iteration', () => {
     });
 
     test('prior', () => {
-      const domModule = dom5.iteration.query(
-          doc, dom5.predicates.hasAttrValue('id', 'test-element'))!;
-      const comments =
-          [...dom5.iteration.prior(domModule)].filter(dom5.isCommentNode);
+      const domModule =
+          dom5.query(doc, dom5.predicates.hasAttrValue('id', 'test-element'))!;
+      const comments = [...dom5.prior(domModule)].filter(dom5.isCommentNode);
       assert.include(dom5.getTextContent(comments[0]), 'test element');
       assert.include(
           dom5.getTextContent(comments[1]), 'hash or path based routing');

--- a/src/test/iteration_test.ts
+++ b/src/test/iteration_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
  * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
@@ -17,7 +17,7 @@ import * as path from 'path';
 import * as dom5 from '../index-next';
 import {fixturesDir} from './utils';
 
-/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="mocha" />
 
 suite('iteration', () => {
   const docText: string = `

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -10,4 +10,5 @@
  */
 
 import * as path from 'path';
+
 export const fixturesDir = path.join(__dirname, '../../src/test/static/');

--- a/src/test/walking_test.ts
+++ b/src/test/walking_test.ts
@@ -51,11 +51,11 @@ suite('walking', () => {
                        .childNodes![1];
 
     assert(dom5.predicates.hasTagName('a')(anchor));
-    const domModule = dom5.walking.nodeWalkAncestors(
+    const domModule = dom5.nodeWalkAncestors(
         anchor, dom5.predicates.hasTagName('dom-module'));
     assert(domModule);
-    const theLinkIsNotAnAncestor = dom5.walking.nodeWalkAncestors(
-        anchor, dom5.predicates.hasTagName('link'));
+    const theLinkIsNotAnAncestor =
+        dom5.nodeWalkAncestors(anchor, dom5.predicates.hasTagName('link'));
     assert.equal(theLinkIsNotAnAncestor, undefined);
   });
 
@@ -71,13 +71,12 @@ suite('walking', () => {
 
     // 'sample element' text node
     let expected = templateContent.childNodes![4];
-    let actual =
-        dom5.walking.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
+    let actual = dom5.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
     assert.equal(actual, expected);
 
     // <!-- comment node -->
     expected = templateContent.childNodes![5];
-    actual = dom5.walking.nodeWalk(
+    actual = dom5.nodeWalk(
         template, dom5.isCommentNode, dom5.childNodesIncludeTemplate);
     assert.equal(actual, expected);
   });
@@ -88,7 +87,7 @@ suite('walking', () => {
         dom5.predicates.hasAttrValue('rel', 'import'),
         dom5.predicates.hasAttr('href'));
     const expected = doc.childNodes![1].childNodes![0].childNodes![0];
-    const actual = dom5.walking.query(doc, fn);
+    const actual = dom5.query(doc, fn);
     assert.equal(actual, expected);
   });
 
@@ -103,7 +102,7 @@ suite('walking', () => {
     const expected = serializedDoc.split('\n').length - 1;
     // add two for normalized text node "\nsample text\n"
     const actual =
-        dom5.walking.nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate)
+        dom5.nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate)
             .length +
         2;
 
@@ -126,8 +125,7 @@ suite('walking', () => {
     const expected_1 = templateContent.childNodes![1];
     // anchor
     const expected_2 = templateContent.childNodes![3];
-    const actual =
-        dom5.walking.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
+    const actual = dom5.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
 
     assert.equal(actual.length, 3);
     assert.equal(actual[0], expected_1);
@@ -143,10 +141,9 @@ suite('walking', () => {
     });
 
     test('nodeWalkAllPrior', () => {
-      const domModule = dom5.walking.nodeWalkAll(
+      const domModule = dom5.nodeWalkAll(
           doc, dom5.predicates.hasAttrValue('id', 'test-element'))[0];
-      const comments =
-          dom5.walking.nodeWalkAllPrior(domModule, dom5.isCommentNode);
+      const comments = dom5.nodeWalkAllPrior(domModule, dom5.isCommentNode);
       assert.include(dom5.getTextContent(comments[0]), 'test element');
       assert.include(
           dom5.getTextContent(comments[1]), 'hash or path based routing');

--- a/src/test/walking_test.ts
+++ b/src/test/walking_test.ts
@@ -1,0 +1,160 @@
+/**
+ * @license
+ * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import {assert} from 'chai';
+import * as fs from 'fs';
+import * as parse5 from 'parse5';
+import * as path from 'path';
+
+import * as dom5 from '../index';
+import {fixturesDir} from './utils';
+
+/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
+
+suite('walking', () => {
+  const docText: string = `
+<!DOCTYPE html>
+<link rel="import" href="polymer.html">
+<dom-module id="my-el">
+<template>
+  <img src="foo.jpg">
+  <a href="next-page.html">Anchor</a>
+  sample element
+  <!-- comment node -->
+</template>
+<div>
+  <a href="another-anchor">Anchor2</a>
+</div>
+</dom-module>
+<script>Polymer({is: "my-el"})</script>
+`.replace(/  /g, '');
+  let doc: parse5.ASTNode;
+
+  setup(() => {
+    doc = parse5.parse(docText);
+  });
+
+  test('nodeWalkAncestors', () => {
+    // doc -> dom-module -> div -> a
+    const anchor = doc.childNodes![1]
+                       .childNodes![1]
+                       .childNodes![0]
+                       .childNodes![3]
+                       .childNodes![1];
+
+    assert(dom5.predicates.hasTagName('a')(anchor));
+    const domModule = dom5.walking.nodeWalkAncestors(
+        anchor, dom5.predicates.hasTagName('dom-module'));
+    assert(domModule);
+    const theLinkIsNotAnAncestor = dom5.walking.nodeWalkAncestors(
+        anchor, dom5.predicates.hasTagName('link'));
+    assert.equal(theLinkIsNotAnAncestor, undefined);
+  });
+
+  test('nodeWalk', () => {
+    // doc -> body -> dom-module -> template
+    const template =
+        doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+    const templateContent =
+        parse5.treeAdapters.default.getTemplateContent(template);
+
+    const textNode = dom5.predicates.AND(
+        dom5.isTextNode, dom5.predicates.hasTextValue('\nsample element\n'));
+
+    // 'sample element' text node
+    let expected = templateContent.childNodes![4];
+    let actual =
+        dom5.walking.nodeWalk(doc, textNode, dom5.childNodesIncludeTemplate);
+    assert.equal(actual, expected);
+
+    // <!-- comment node -->
+    expected = templateContent.childNodes![5];
+    actual = dom5.walking.nodeWalk(
+        template, dom5.isCommentNode, dom5.childNodesIncludeTemplate);
+    assert.equal(actual, expected);
+  });
+
+  test('query', () => {
+    const fn = dom5.predicates.AND(
+        dom5.predicates.hasTagName('link'),
+        dom5.predicates.hasAttrValue('rel', 'import'),
+        dom5.predicates.hasAttr('href'));
+    const expected = doc.childNodes![1].childNodes![0].childNodes![0];
+    const actual = dom5.walking.query(doc, fn);
+    assert.equal(actual, expected);
+  });
+
+  test('nodeWalkAll', () => {
+    const empty = dom5.predicates.AND(dom5.isTextNode, function(node) {
+      return !/\S/.test(node.value!);
+    });
+
+    // serialize to count for inserted <head> and <body>
+    const serializedDoc = parse5.serialize(doc);
+    // subtract one to get "gap" number
+    const expected = serializedDoc.split('\n').length - 1;
+    // add two for normalized text node "\nsample text\n"
+    const actual =
+        dom5.walking.nodeWalkAll(doc, empty, [], dom5.childNodesIncludeTemplate)
+            .length +
+        2;
+
+    assert.equal(actual, expected);
+  });
+
+  test('queryAll', () => {
+    const fn = dom5.predicates.AND(
+        dom5.predicates.OR(
+            dom5.predicates.hasAttr('href'), dom5.predicates.hasAttr('src')),
+        dom5.predicates.NOT(dom5.predicates.hasTagName('link')));
+
+    // doc -> body -> dom-module -> template
+    const template =
+        doc.childNodes![1].childNodes![1].childNodes![0].childNodes![1];
+    const templateContent =
+        parse5.treeAdapters.default.getTemplateContent(template);
+
+    // img
+    const expected_1 = templateContent.childNodes![1];
+    // anchor
+    const expected_2 = templateContent.childNodes![3];
+    const actual =
+        dom5.walking.queryAll(doc, fn, [], dom5.childNodesIncludeTemplate);
+
+    assert.equal(actual.length, 3);
+    assert.equal(actual[0], expected_1);
+    assert.equal(actual[1], expected_2);
+  });
+  suite('NodeWalkAllPrior', () => {
+    const docText = fs.readFileSync(
+        path.join(fixturesDir, 'multiple-comments.html'), 'utf8');
+    let doc: parse5.ASTNode;
+
+    setup(() => {
+      doc = parse5.parse(docText);
+    });
+
+    test('nodeWalkAllPrior', () => {
+      const domModule = dom5.walking.nodeWalkAll(
+          doc, dom5.predicates.hasAttrValue('id', 'test-element'))[0];
+      const comments =
+          dom5.walking.nodeWalkAllPrior(domModule, dom5.isCommentNode);
+      assert.include(dom5.getTextContent(comments[0]), 'test element');
+      assert.include(
+          dom5.getTextContent(comments[1]), 'hash or path based routing');
+      assert.include(
+          dom5.getTextContent(comments[2]), 'core-route-selectable.html');
+      assert.include(
+          dom5.getTextContent(comments[comments.length - 1]),
+          'The Polymer Project Authors');
+    });
+  });
+});

--- a/src/test/walking_test.ts
+++ b/src/test/walking_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
  * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
@@ -17,7 +17,7 @@ import * as path from 'path';
 import * as dom5 from '../index';
 import {fixturesDir} from './utils';
 
-/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="mocha" />
 
 suite('walking', () => {
   const docText: string = `

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ASTNode as Node} from 'parse5';
+import {ASTNode as Node, treeAdapters} from 'parse5';
 
 import {constructors} from './modification';
 import {isCommentNode, isDocument, isDocumentFragment, isElement, isTextNode} from './predicates';
@@ -155,3 +155,18 @@ export function setTextContent(node: Node, value: string) {
     node.childNodes = [tn];
   }
 }
+
+export type GetChildNodes = ((node: Node) => Node[] | undefined);
+
+export const defaultChildNodes = function defaultChildNodes(node: Node) {
+  return node.childNodes;
+};
+
+export const childNodesIncludeTemplate = function childNodesIncludeTemplate(
+    node: Node) {
+  if (node.nodeName === 'template') {
+    return treeAdapters.default.getTemplateContent(node).childNodes;
+  }
+
+  return node.childNodes;
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at

--- a/src/walking.ts
+++ b/src/walking.ts
@@ -12,8 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ASTNode as Node, treeAdapters} from 'parse5';
+import {ASTNode as Node} from 'parse5';
 
+import * as iterables from './iteration';
 import {isElement, Predicate, predicates as p} from './predicates';
 
 export {ASTNode as Node} from 'parse5';
@@ -23,25 +24,33 @@ export {ASTNode as Node} from 'parse5';
  * list of results.
  */
 export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
-  let results: U[] = [];
-  nodeWalk(node, function(node) {
-    results = results.concat(mapfn(node));
-    return false;
-  });
-  return results;
+  return Array.from(iterables.treeMap(node, mapfn));
 }
 
 export type GetChildNodes = (node: Node) => Node[] | undefined;
 
-export const defaultChildNodes: GetChildNodes = node => node.childNodes;
+export const defaultChildNodes = iterables.defaultChildNodes;
 
-export const childNodesIncludeTemplate: GetChildNodes = node => {
-  if (node.nodeName === 'template') {
-    return treeAdapters.default.getTemplateContent(node).childNodes;
+export const childNodesIncludeTemplate = iterables.childNodesIncludeTemplate;
+
+function find<U>(iter: Iterable<U>, predicate: (u: U) => boolean) {
+  for (const value of iter) {
+    if (predicate(value)) {
+      return value;
+    }
   }
+  return null;
+}
 
-  return node.childNodes;
-};
+function filter<U>(
+    iter: Iterable<U>, predicate: (u: U) => boolean, matches: U[] = []) {
+  for (const value of iter) {
+    if (predicate(value)) {
+      matches.push(value);
+    }
+  }
+  return matches;
+}
 
 /**
  * Walk the tree down from `node`, applying the `predicate` function.
@@ -53,20 +62,7 @@ export function nodeWalk(
     node: Node,
     predicate: Predicate,
     getChildNodes: GetChildNodes = defaultChildNodes): Node|null {
-  if (predicate(node)) {
-    return node;
-  }
-  let match: Node|null = null;
-  const childNodes = getChildNodes(node);
-  if (childNodes) {
-    for (let i = 0; i < childNodes.length; i++) {
-      match = nodeWalk(childNodes[i], predicate, getChildNodes);
-      if (match) {
-        break;
-      }
-    }
-  }
-  return match;
+  return find(iterables.depthFirst(node, getChildNodes), predicate);
 }
 
 /**
@@ -79,88 +75,39 @@ export function nodeWalkAll(
     predicate: Predicate,
     matches?: Node[],
     getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
-  if (!matches) {
-    matches = [];
-  }
-  if (predicate(node)) {
-    matches.push(node);
-  }
-  const childNodes = getChildNodes(node);
-  if (childNodes) {
-    for (let i = 0; i < childNodes.length; i++) {
-      nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
-    }
-  }
-  return matches;
-}
-
-function _reverseNodeWalkAll(
-    node: Node,
-    predicate: Predicate,
-    matches: Node[],
-    getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
-  if (!matches) {
-    matches = [];
-  }
-  const childNodes = getChildNodes(node);
-  if (childNodes) {
-    for (let i = childNodes.length - 1; i >= 0; i--) {
-      nodeWalkAll(childNodes[i], predicate, matches, getChildNodes);
-    }
-  }
-  if (predicate(node)) {
-    matches.push(node);
-  }
-  return matches;
+  return filter(iterables.depthFirst(node, getChildNodes), predicate, matches);
 }
 
 /**
  * Equivalent to `nodeWalk`, but only returns nodes that are either
- * ancestors or earlier cousins/siblings in the document.
+ * ancestors or earlier siblings in the document.
  *
  * Nodes are searched in reverse document order, starting from the sibling
  * prior to `node`.
  */
 export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
     undefined {
-  // Search our earlier siblings and their descendents.
-  const parent = node.parentNode;
-  if (parent && parent.childNodes) {
-    const idx = parent.childNodes.indexOf(node);
-    const siblings = parent.childNodes.slice(0, idx);
-    for (let i = siblings.length - 1; i >= 0; i--) {
-      const sibling = siblings[i];
-      if (predicate(sibling)) {
-        return sibling;
-      }
-      const found = nodeWalk(sibling, predicate);
-      if (found) {
-        return found;
-      }
-    }
-    if (predicate(parent)) {
-      return parent;
-    }
-    return nodeWalkPrior(parent, predicate);
-  }
-  return undefined;
-}
-
-/**
- * Walk the tree up from the parent of `node`, to its grandparent and so on to
- * the root of the tree.  Return the first ancestor that matches the given
- * predicate.
- */
-export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
-    undefined {
-  const parent = node.parentNode;
-  if (!parent) {
+  const result = find(iteratePrior(node), predicate);
+  if (result === null) {
     return undefined;
   }
-  if (predicate(parent)) {
-    return parent;
+  return result;
+}
+
+function* iteratePrior(node: Node): IterableIterator<Node> {
+  for (const previousSibling of iterables.previousSiblings(node)) {
+    yield* iterables.depthFirstReversed(previousSibling);
   }
-  return nodeWalkAncestors(parent, predicate);
+  const parent = node.parentNode;
+  if (parent) {
+    yield parent;
+    yield* iteratePrior(parent);
+  }
+}
+
+function* iteratePriorIncludingNode(node: Node) {
+  yield node;
+  yield* iteratePrior(node);
 }
 
 /**
@@ -171,23 +118,21 @@ export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
  */
 export function nodeWalkAllPrior(
     node: Node, predicate: Predicate, matches?: Node[]): Node[] {
-  if (!matches) {
-    matches = [];
+  return filter(iteratePriorIncludingNode(node), predicate, matches);
+}
+
+/**
+ * Walk the tree up from the parent of `node`, to its grandparent and so on to
+ * the root of the tree.  Return the first ancestor that matches the given
+ * predicate.
+ */
+export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
+    undefined {
+  const result = find(iterables.ancestors(node), predicate);
+  if (result === null) {
+    return undefined;
   }
-  if (predicate(node)) {
-    matches.push(node);
-  }
-  // Search our earlier siblings and their descendents.
-  const parent = node.parentNode;
-  if (parent) {
-    const idx = parent.childNodes!.indexOf(node);
-    const siblings = parent.childNodes!.slice(0, idx);
-    for (let i = siblings.length - 1; i >= 0; i--) {
-      _reverseNodeWalkAll(siblings[i], predicate, matches);
-    }
-    nodeWalkAllPrior(parent, predicate, matches);
-  }
-  return matches;
+  return result;
 }
 
 /**

--- a/src/walking.ts
+++ b/src/walking.ts
@@ -16,6 +16,7 @@ import {ASTNode as Node} from 'parse5';
 
 import * as iterables from './iteration';
 import {isElement, Predicate, predicates as p} from './predicates';
+import {defaultChildNodes, GetChildNodes} from './util';
 
 export {ASTNode as Node} from 'parse5';
 
@@ -26,12 +27,6 @@ export {ASTNode as Node} from 'parse5';
 export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
   return Array.from(iterables.treeMap(node, mapfn));
 }
-
-export type GetChildNodes = (node: Node) => Node[] | undefined;
-
-export const defaultChildNodes = iterables.defaultChildNodes;
-
-export const childNodesIncludeTemplate = iterables.childNodesIncludeTemplate;
 
 function find<U>(iter: Iterable<U>, predicate: (u: U) => boolean) {
   for (const value of iter) {

--- a/src/walking.ts
+++ b/src/walking.ts
@@ -14,7 +14,7 @@
 
 import {ASTNode as Node} from 'parse5';
 
-import * as iterables from './iteration';
+import * as iteration from './iteration';
 import {isElement, Predicate, predicates as p} from './predicates';
 import {defaultChildNodes, GetChildNodes} from './util';
 
@@ -25,7 +25,7 @@ export {ASTNode as Node} from 'parse5';
  * list of results.
  */
 export function treeMap<U>(node: Node, mapfn: (node: Node) => U[]): U[] {
-  return Array.from(iterables.treeMap(node, mapfn));
+  return Array.from(iteration.treeMap(node, mapfn));
 }
 
 function find<U>(iter: Iterable<U>, predicate: (u: U) => boolean) {
@@ -57,7 +57,7 @@ export function nodeWalk(
     node: Node,
     predicate: Predicate,
     getChildNodes: GetChildNodes = defaultChildNodes): Node|null {
-  return find(iterables.depthFirst(node, getChildNodes), predicate);
+  return find(iteration.depthFirst(node, getChildNodes), predicate);
 }
 
 /**
@@ -70,7 +70,7 @@ export function nodeWalkAll(
     predicate: Predicate,
     matches?: Node[],
     getChildNodes: GetChildNodes = defaultChildNodes): Node[] {
-  return filter(iterables.depthFirst(node, getChildNodes), predicate, matches);
+  return filter(iteration.depthFirst(node, getChildNodes), predicate, matches);
 }
 
 /**
@@ -82,27 +82,16 @@ export function nodeWalkAll(
  */
 export function nodeWalkPrior(node: Node, predicate: Predicate): Node|
     undefined {
-  const result = find(iteratePrior(node), predicate);
+  const result = find(iteration.prior(node), predicate);
   if (result === null) {
     return undefined;
   }
   return result;
 }
 
-function* iteratePrior(node: Node): IterableIterator<Node> {
-  for (const previousSibling of iterables.previousSiblings(node)) {
-    yield* iterables.depthFirstReversed(previousSibling);
-  }
-  const parent = node.parentNode;
-  if (parent) {
-    yield parent;
-    yield* iteratePrior(parent);
-  }
-}
-
 function* iteratePriorIncludingNode(node: Node) {
   yield node;
-  yield* iteratePrior(node);
+  yield* iteration.prior(node);
 }
 
 /**
@@ -123,7 +112,7 @@ export function nodeWalkAllPrior(
  */
 export function nodeWalkAncestors(node: Node, predicate: Predicate): Node|
     undefined {
-  const result = find(iterables.ancestors(node), predicate);
+  const result = find(iteration.ancestors(node), predicate);
   if (result === null) {
     return undefined;
   }

--- a/src/walking.ts
+++ b/src/walking.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

dom5 was written before the Iterator protocol was standardized and widely available. Iteration is more flexible, faster, and easier to use than callback-based walking functions.

This commit adds a new module `iterables` that implements a few primitives for walking parse5 trees, then implements the existing callback-based functions on top.