### PR TITLE
Prepare to release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
-## [v3.0.0](https://github.com/Polymer/dom5/tree/v3.0.0) (2017-02-12)
+## [v3.0.0](https://github.com/Polymer/dom5/tree/v3.0.0) (2018-02-12)
 - [BREAKING] Updated to parse5 v4. See:
   - http://inikulin.github.io/parse5/#4-0-0 and
     http://inikulin.github.io/parse5/#3-0-0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [v3.0.0](https://github.com/Polymer/dom5/tree/v3.0.0) (2017-02-12)
 - [BREAKING] Updated to parse5 v4. See:
   - http://inikulin.github.io/parse5/#4-0-0 and
     http://inikulin.github.io/parse5/#3-0-0


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

It's pretty minimally breaking, but we are dropping support for node v6, and we're bumping two versions forward with parse5