### PR TITLE
Export iteration methods and prepare patch release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
+## [v3.0.1](https://github.com/Polymer/dom5/tree/v3.0.1) (2018-03-27)
+- Export iteration methods into main module.
+
 ## [v3.0.0](https://github.com/Polymer/dom5/tree/v3.0.0) (2018-02-12)
 - [BREAKING] Updated to parse5 v4. See:
   - http://inikulin.github.io/parse5/#4-0-0 and

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export * from './modification';
 export * from './predicates';
 export * from './util';
 export * from './walking';
+export * from './iteration';


### PR DESCRIPTION
I'm guessing these are supposed to be public, since the CHANGELOG for the previous release says these methods should be used going forward.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
